### PR TITLE
Only reload non-discarded tabs; still blocks when they're active again.

### DIFF
--- a/extension/utils.js
+++ b/extension/utils.js
@@ -95,7 +95,7 @@ function getFocusURLFromProxyURL(blockedURL) {
 
 function forAllTabs(cb) {
     var vendor = getBrowserType();
-    vendor.tabs.query({}, function(tabs) {
+    vendor.tabs.query({discarded: false}, function(tabs) {
         for (var tab of tabs) {
             cb(tab);
         }


### PR DESCRIPTION
I use discarded tabs a lot, so whenever Focus toggles, it will make my computer completely unusable for a few minutes as it reloads 100+ tabs at once.

This change makes Focus only reload non-discarded tabs.

As soon as a discarded tab is un-discarded, Focus will affect it to, so this change does not introduce any "loop holes". :)