### PR TITLE
Fix Extension not working on Microsoft Edge (Mac)

### DIFF
--- a/extension/focus.js
+++ b/extension/focus.js
@@ -69,8 +69,8 @@ function handleBeforeNavigate(navDetails) {
 function processTabs() {
     //console.log("processTabs");
 
-    browser.tabs.query({}, function(tabs) {
-        if (browser.runtime.lastError) {
+    vendor.tabs.query({}, function(tabs) {
+        if (vendor.runtime.lastError) {
             console.log("error fetching tabs", error);
             return;
         }
@@ -97,5 +97,5 @@ function checkTabURL(tabId, url) {
     }
 }
 
-browser.webNavigation.onBeforeNavigate.addListener(handleBeforeNavigate);
+vendor.webNavigation.onBeforeNavigate.addListener(handleBeforeNavigate);
 


### PR DESCRIPTION
#### Because:
* The loaded extension was not blocking any websites on Microsoft Edge (for Mac)

#### This commit: 
* Replaces the `browser` property with `vendor` (based on the solution proposed by @arryanggaputra on the issues panel.

#### Tested with:
* Microsoft Edge 85.0.564.51 
* MacOS Catalina 10.15.6 (19G2021)
* Focus v1.11