### PR TITLE
chore: refactor dark theme support

### DIFF
--- a/extension/block.html
+++ b/extension/block.html
@@ -99,10 +99,6 @@
             font-family: -apple-system, BlinkMacSystemFont, sans-serif;
         }
 
-        body.dark {
-            background: #111111;
-        }
-
         #bg {
             width: 100%;
             height: 100%;
@@ -113,14 +109,6 @@
             opacity: 0.3;
             position: absolute;
             z-index: 1;
-        }
-
-        .light #bg {
-            opacity: 0.3;
-        }
-
-        .dark #bg {
-            opacity: 0.05;
         }
 
         #wrapper {
@@ -147,10 +135,6 @@
             z-index: 100;
         }
 
-        .dark #quote {
-            color: #fff;
-        }
-
         #author {
             position: relative;
             font-size: 30px;
@@ -160,11 +144,6 @@
             display: block;
             text-align: center;
             z-index: 99;
-        }
-
-        .dark #author {
-            color: #fff;
-            opacity: 0.7;
         }
 
         #url {
@@ -184,15 +163,6 @@
 
         #info a {
             color: #999999;
-        }
-
-        .dark #info {
-            color: #ffffff;
-            opacity: 0.3;
-        }
-
-        .dark #info a {
-            color: #ffffff;
         }
 
         @media screen and (max-width: 1300px) {
@@ -273,6 +243,35 @@
                 display: none !important;
             }
         }
+
+        /* Dark theme styles */
+        @media (prefers-color-scheme: dark) {
+            body {
+                background: #111111;
+            }
+
+            #bg {
+                opacity: 0.05;
+            }
+
+            #quote {
+                color: #fff;
+            }
+
+            #author {
+                color: #fff;
+                opacity: 0.7;
+            }
+
+            #info {
+                color: #ffffff;
+                opacity: 0.3;
+            }
+
+            #info a {
+                color: #ffffff;
+            }
+        }
     </style>
 </head>
 
@@ -283,7 +282,7 @@
             <cite id="author"></cite>
             <div id="bg"></div>
         </div>
-        <div id="info"><a href="" id="url"></a> blocked by <a href="https://heyfocus.com/?utm_source=focus_template">Focus</a> / <a href="" id="toggle-theme">Switch themes</a></div>
+        <div id="info"><a href="" id="url"></a> blocked by <a href="https://heyfocus.com/?utm_source=focus_template">Focus</a></div>
     </div>
     <script src="block.js"></script>
 </body>

--- a/extension/block.js
+++ b/extension/block.js
@@ -50,29 +50,4 @@ window.onpageshow = function (event) {
     }
 };
 
-function toggleTheme() {
-    var isDark = document.querySelector("body").classList.toggle("dark")
-    localStorage.removeItem("FocusIsDarkTheme");
-    localStorage.setItem("FocusIsDarkTheme", isDark);
-}
-
-function initialize() {
-    document.getElementById("toggle-theme").addEventListener("click", function (e) {
-        e.preventDefault();
-        toggleTheme();
-    });
-
-    var isDarkTheme = false;
-
-    try {
-        isDarkTheme = JSON.parse(localStorage.getItem("FocusIsDarkTheme"));
-    } catch (e) { }
-
-    if (isDarkTheme) {
-        toggleTheme();
-    }
-
-    updateState();
-}
-
-initialize();
+updateState();


### PR DESCRIPTION
This PR aims to remove the "Toggle theme" functionality and instead use CSS to follow the user's system theme.

This will make it easier for users to always have the block screen using the correct theme instead of a white screen even when using a dark theme and having to manually toggle the desired theme.